### PR TITLE
Feat: Added a option to fill in a sync server

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -7,21 +7,24 @@ import (
 )
 
 var (
-	serverAddr string = "localhost:50000" // Change this to your server address
+	serverAddr string
 	conn       net.Conn
 	folderPath = "../local"
 	filePath   = "../local/input.txt"
 )
 
 func main() {
+	runMainMenu()
+}
+
+func makeConnection() {
 	// Establish TCP connection
 	if err := establishConnection(); err != nil {
 		fmt.Println("Failed to connect to server:", err)
 		return
 	}
 	defer conn.Close()
-
-	runMainMenu()
+	runSyncMenu()
 }
 
 func establishConnection() error {
@@ -37,7 +40,7 @@ func closeConnection() {
 }
 
 func runMainMenu() {
-	options := []string{"Sync", "Options", "Quit"}
+	options := []string{"Connect to server", "Sync", "Options", "Quit"}
 	displayMenu(options)
 
 	var choice int
@@ -49,10 +52,12 @@ func runMainMenu() {
 
 	switch choice {
 	case 1:
-		runSyncMenu()
+		makeConnection()
 	case 2:
-		runOptiesMenu()
+		runSyncMenu()
 	case 3:
+		runOptiesMenu()
+	case 4:
 		fmt.Println("Exiting program...")
 		closeConnection() // Close connection before exiting
 		os.Exit(0)
@@ -83,7 +88,7 @@ func runSyncMenu() {
 }
 
 func runOptiesMenu() {
-	options := []string{"Sync server", "Back"}
+	options := []string{"Set sync server", "Show current sync server", "Back"}
 	displayMenu(options)
 
 	var choice int
@@ -95,9 +100,10 @@ func runOptiesMenu() {
 
 	switch choice {
 	case 1:
-		fmt.Println("Executing sync server option...")
 		syncServer()
 	case 2:
+		showCurrentServer()
+	case 3:
 		runMainMenu()
 	}
 }

--- a/client/options.go
+++ b/client/options.go
@@ -3,5 +3,13 @@ package main
 import "fmt"
 
 func syncServer() {
-	fmt.Println("Executing opties...")
+	fmt.Println("Enter server address:")
+	fmt.Scanln(&serverAddr)
+	fmt.Println("Server address set to:", serverAddr)
+	runOptiesMenu()
+}
+
+func showCurrentServer() {
+	fmt.Println("Server address set to:", serverAddr)
+	runOptiesMenu()
 }


### PR DESCRIPTION
In deze PR is er een optie toegevoegd om een sync server op te geven in plaats van dat deze hardcoded in de code staat.

Hierdoor is er een optie toegevoegd zodra het serveradres is opgegeven om daarna pas te connecten met de betreffende server ipv dat er al een connectie nodig is bij het starten van de client.

De vraag is alleen, willen we dit?